### PR TITLE
Updated guardian screen and summary screen rendering conditions

### DIFF
--- a/src/contexts/FormContext/FormContext.tsx
+++ b/src/contexts/FormContext/FormContext.tsx
@@ -102,10 +102,19 @@ export function FormContextProvider({
     }
   }, [errors, validateForm]);
 
+  /**
+   * Invalidate form based on the current step. The "value.setIsFormSubmitted" will toggle between fields and summary.
+   */
+
   const handleInvalidateForm = useCallback(() => {
-    value.setIsFormSubmitted(false);
-    setIsGuardianScreenVisible(false);
-  }, []);
+    if (!isGuardianScreenVisible) {
+      value.setIsFormSubmitted(false);
+    }
+
+    if (isGuardianScreenVisible) {
+      setIsGuardianScreenVisible(false);
+    }
+  }, [isGuardianScreenVisible]);
 
   const contextValue: FormContextPropsType = {
     ...value,


### PR DESCRIPTION
**Issue**
Pressing the "back" button on the guardian screen would jump back to the input step, instead of the summary, which is the middle step, in this scenario.

**Reproduce**
Press the "back" button on the guardian screen and you'll see it'll jump you to the first step instead of the second.

**Root cause**
Pressing the back button would toggle off both summary and inputs rendering conditions, instead of toggling them separately based on the active one. 