### PR TITLE
[FIX] Changed `nonce` type from `string` to `number`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Changed `nonce` type from `string` to `number`](https://github.com/multiversx/mx-sdk-dapp-form/pull/173)
 
 ## [[0.6.0](https://github.com/multiversx/mx-sdk-dapp-form/pull/172)] - 2023-05-09
 - [Verify ledger version for guarded transactions](https://github.com/multiversx/mx-sdk-dapp-form/pull/171)

--- a/src/validateSignTransactions/tests/validateSignTransactions.test.ts
+++ b/src/validateSignTransactions/tests/validateSignTransactions.test.ts
@@ -5,7 +5,7 @@ describe('validateSignTransactions tests', () => {
     const data = {
       extractedTxs: [
         {
-          nonce: '2587',
+          nonce: 2587,
           value: '0',
           receiver:
             'erd1wh9c0sjr2xn8hzf02lwwcr4jk2s84tat9ud2kaq6zr7xzpvl9l5q8awmex',

--- a/src/validateSignTransactions/validateTransaction/types.ts
+++ b/src/validateSignTransactions/validateTransaction/types.ts
@@ -7,7 +7,7 @@ import { ApiConfigType } from 'apiCalls';
 import { ExtendedValuesType } from 'types';
 
 export type SignTxType = {
-  nonce?: string;
+  nonce?: number;
   data: any;
   token?: string;
   gasLimit?: string;


### PR DESCRIPTION
### Issue
`nonce` is treated as string

### Reproduce
Issue exists on version `0.6.0` of sdk-dapp-form

### Root cause
`nonce` type is string

### Fix
Change `nonce` to number

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User tesing
[] Unit tests
