### PR TITLE
Adds strong type to TokenTickerIcon

### DIFF
--- a/src/UI/Fields/AmountSelect/components/TokenSelect/tokenSelect.types.ts
+++ b/src/UI/Fields/AmountSelect/components/TokenSelect/tokenSelect.types.ts
@@ -41,5 +41,5 @@ export interface TokenSelectPropsType {
   showTokenPrice?: boolean;
   showBalanceUsdValue?: boolean;
   selectedTokenIconClassName?: string;
-  TokenTickerIcon?: <T>(props: T) => JSX.Element;
+  TokenTickerIcon?: ({ token }: { token?: PartialTokenType }) => JSX.Element;
 }


### PR DESCRIPTION
### Issue
TokenTickerIcon is unusable because of weak type

### Reproduce
Issue exists on version `0.6.2` of sdk-dapp-form

### Fix
Added strong type to TokenTickerIcon

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User tesing
[] Unit tests
