### PR TITLE
fix gas limit not updating when changing tokenId with prefilled data

### DIFF
--- a/src/contexts/GasContext/GasContext.tsx
+++ b/src/contexts/GasContext/GasContext.tsx
@@ -206,9 +206,7 @@ export function GasContextProvider({
   }, [isNftTransaction, touched]);
 
   useEffect(() => {
-    if (!prefilledForm) {
-      handleUpdateGasLimit(getGasLimit({ txType, data, isGuarded }), true);
-    }
+    handleUpdateGasLimit(getGasLimit({ txType, data, isGuarded }), true);
   }, [tokenId, txType]);
 
   const value: GasContextPropsType = {


### PR DESCRIPTION
This PR fixes the issue where, if changing from EGLD to RIDE with all other details being prefilled, the gasLimit stays at 50k instead of updating to 500k