### PR TITLE
Added the dapp-form prefix to the global css variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Added dapp-form prefix to css variables](https://github.com/multiversx/mx-sdk-dapp-form/pull/250)
+
 ## [[0.8.18](https://github.com/multiversx/mx-sdk-dapp-form/pull/249)] - 2023-10-31
 
 - [Fixed receiver on mobile, added leading zeroes condition on "AmountInput"](https://github.com/multiversx/mx-sdk-dapp-form/pull/246)

--- a/example/src/assets/sass/theme.scss
+++ b/example/src/assets/sass/theme.scss
@@ -3,11 +3,11 @@
 
 $body: #000;
 $headings-font-weight: 300;
-$primary: var(--primary);
-$light: var(--light);
+$primary: var(--dapp-form-primary);
+$light: var(--dapp-form-light);
 
 $headings-font-weight: 300;
-$a: var(--primary-light);
+$a: var(--dapp-form-primary-light);
 
 /* Do not move the imports from here.
 Override Bootstrap variables only above.
@@ -36,7 +36,7 @@ html {
 .dapp-icon {
   padding: 5px;
   border-radius: 50%;
-  background-color: var(--light);
+  background-color: var(--dapp-form-light);
   width: 65px;
   height: 65px;
   display: flex;

--- a/example/src/pages/Dashboard/styles.module.scss
+++ b/example/src/pages/Dashboard/styles.module.scss
@@ -18,12 +18,12 @@
     line-height: 1;
     cursor: pointer;
     transition: all 400ms ease;
-    background-color: var(--white);
-    color: var(--black);
+    background-color: var(--dapp-form-white);
+    color: var(--dapp-form-black);
 
     &.active {
-      background-color: var(--black);
-      color: var(--white);
+      background-color: var(--dapp-form-black);
+      color: var(--dapp-form-white);
     }
   }
 }
@@ -35,7 +35,7 @@
 
 .content {
   border-radius: 15px;
-  border: 1px solid var(--primary);
+  border: 1px solid var(--dapp-form-primary);
   display: inline-block;
   margin: 30px;
   width: 100%;

--- a/src/UI/Fields/AmountSelect/components/AmountInput/amountInput.module.scss
+++ b/src/UI/Fields/AmountSelect/components/AmountInput/amountInput.module.scss
@@ -4,7 +4,7 @@
   background-color: transparent;
   border: none;
   box-shadow: none;
-  color: var(--black);
+  color: var(--dapp-form-black);
   font-variant-numeric: tabular-nums;
   font-weight: 500;
   height: 100%;

--- a/src/UI/Fields/AmountSlider/styles.module.scss
+++ b/src/UI/Fields/AmountSlider/styles.module.scss
@@ -13,7 +13,7 @@
       transform: translateY(-50%);
       content: '';
       position: absolute;
-      background: var(--border-color);
+      background: var(--dapp-form-border-color);
       height: 4px;
     }
 
@@ -43,23 +43,23 @@
       top: 50%;
       transform: translateY(-50%);
       border-radius: 50%;
-      background-color: var(--black);
+      background-color: var(--dapp-form-black);
       z-index: 5;
 
       &.disabled {
-        background-color: var(--secondary);
+        background-color: var(--dapp-form-secondary);
       }
 
       .amountSliderThumbPercentage {
         line-height: 1;
         opacity: 0;
         transition: all 400ms ease;
-        color: var(--white);
+        color: var(--dapp-form-white);
         font-weight: 500;
         position: absolute;
         left: 50%;
         padding: 0.25rem 0.35rem;
-        background: var(--black);
+        background: var(--dapp-form-black);
         border-radius: var(--dapp-form-input-border-radius);
         font-size: 11px;
         transform: translateX(-50%);
@@ -69,7 +69,7 @@
 
     .amountSliderCompletion {
       height: 4px;
-      background: var(--primary);
+      background: var(--dapp-form-primary);
       position: absolute;
       top: 50%;
       left: 0;
@@ -78,7 +78,7 @@
       margin-left: 2px;
 
       &.disabled {
-        background: var(--secondary);
+        background: var(--dapp-form-secondary);
       }
     }
 
@@ -94,8 +94,8 @@
         position: absolute;
         height: 12px;
         border-radius: 50%;
-        background-color: var(--white);
-        border: 2px solid var(--primary);
+        background-color: var(--dapp-form-white);
+        border: 2px solid var(--dapp-form-primary);
         width: 12px;
         top: 50%;
         left: 50%;
@@ -103,15 +103,15 @@
       }
 
       &.completed:after {
-        background-color: var(--primary);
+        background-color: var(--dapp-form-primary);
 
         &.disabled:after {
-          background-color: var(--secondary);
+          background-color: var(--dapp-form-secondary);
         }
       }
 
       &.disabled:after {
-        border-color: var(--secondary);
+        border-color: var(--dapp-form-secondary);
       }
     }
 
@@ -122,7 +122,7 @@
       z-index: 7;
       padding: 1.5rem 0 0;
       line-height: 1;
-      color: var(--black);
+      color: var(--dapp-form-black);
       font-size: 12px;
       cursor: pointer;
 

--- a/src/UI/Fields/Receiver/styles.module.scss
+++ b/src/UI/Fields/Receiver/styles.module.scss
@@ -16,10 +16,10 @@
       float: left;
       min-width: 10rem;
       font-size: 1rem;
-      color: var(--brown);
+      color: var(--dapp-form-brown);
       text-align: left;
       list-style: none;
-      background-color: var(--white);
+      background-color: var(--dapp-form-white);
       background-clip: padding-box;
       border: 1px solid rgba(#000000, 0.15);
       border-radius: var(--dapp-form-input-border-radius);
@@ -36,7 +36,7 @@
         padding: 0.25rem 1.5rem;
         clear: both;
         font-weight: 400;
-        color: var(--brown);
+        color: var(--dapp-form-brown);
         text-align: inherit;
         white-space: nowrap;
         background-color: transparent;
@@ -78,7 +78,7 @@
     }
 
     &.focused {
-      border-color: var(--primary);
+      border-color: var(--dapp-form-primary);
     }
 
     &.expanded {
@@ -137,7 +137,7 @@
             .receiver-select-single-username-icon {
               height: 20px;
               width: 20px;
-              background: var(--black);
+              background: var(--dapp-form-black);
               border-radius: 4px;
               padding: 3px;
               padding-bottom: 2px;
@@ -310,7 +310,7 @@
           left: 12px;
           height: 20px;
           width: 20px;
-          background: var(--black);
+          background: var(--dapp-form-black);
           border-radius: 4px;
           padding: 3px;
           padding-bottom: 2px;
@@ -353,7 +353,7 @@
           border: 4px solid rgba(0, 0, 0, 0);
           background-clip: padding-box;
           border-radius: 9999px;
-          background-color: var(--border-color);
+          background-color: var(--dapp-form-border-color);
         }
 
         &::-webkit-scrollbar-thumb,
@@ -463,7 +463,7 @@
               position: absolute;
               top: 50%;
               transform: translateY(-50%);
-              background: var(--black);
+              background: var(--dapp-form-black);
               border-radius: 4px;
               left: 0;
               padding: 3px;

--- a/src/UI/InfoDust/styles.module.scss
+++ b/src/UI/InfoDust/styles.module.scss
@@ -6,10 +6,10 @@
 
   .infoDustTrigger {
     cursor: pointer;
-    color: var(--primary-light);
+    color: var(--dapp-form-primary-light);
 
     &:hover {
-      color: var(--link-hover-color);
+      color: var(--dapp-form-link-hover-color);
     }
   }
 
@@ -17,9 +17,9 @@
     width: 200px;
     max-width: 200px;
     padding: 0.25rem 0.5rem;
-    color: var(--white);
+    color: var(--dapp-form-white);
     text-align: center;
     border-radius: var(--dapp-form-input-border-radius);
-    background-color: var(--black);
+    background-color: var(--dapp-form-black);
   }
 }

--- a/src/assets/sass/globals.module.scss
+++ b/src/assets/sass/globals.module.scss
@@ -140,21 +140,21 @@
     border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 
   &.btnPrimary {
-    background-color: var(--primary);
-    color: var(--white);
+    background-color: var(--dapp-form-primary);
+    color: var(--dapp-form-white);
 
     &:hover {
-      background-color: var(--btn-blue);
+      background-color: var(--dapp-form-btn-blue);
     }
   }
 
   &.btnWarning {
-    background-color: var(--warning);
-    color: var(--brown);
+    background-color: var(--dapp-form-warning);
+    color: var(--dapp-form-brown);
   }
 
   &.btnLink {
-    color: var(--primary-light);
+    color: var(--dapp-form-primary-light);
     background: none;
     padding: 0;
 

--- a/src/assets/sass/main.scss
+++ b/src/assets/sass/main.scss
@@ -1,6 +1,6 @@
 * {
   $headings-font-weight: 300;
-  $light: var(--light);
+  $light: var(--dapp-form-light);
 
   @import './themes/theme.scss';
 

--- a/src/assets/sass/modules/modal/_modal.scss
+++ b/src/assets/sass/modules/modal/_modal.scss
@@ -37,7 +37,7 @@
       }
 
       .card {
-        background-color: var(--card-bg);
+        background-color: var(--dapp-form-card-bg);
         border-radius: 0;
         box-shadow: none;
         border: none;
@@ -64,7 +64,7 @@
       height: 48px;
       justify-content: center;
       align-items: center;
-      background-color: var(--primary-light);
+      background-color: var(--dapp-form-primary-light);
       border: 1px solid #007ded;
       box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.04);
       border-radius: 6px;
@@ -79,14 +79,14 @@
       max-width: 100%;
     }
     .btn-light {
-      color: var(--primary-light);
+      color: var(--dapp-form-primary-light);
       background: #f3f9ff;
       border: 1px solid #ddeeff;
       box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.04);
       border-radius: 6px;
       &:hover,
       &:active {
-        color: var(--primary-light);
+        color: var(--dapp-form-primary-light);
         background-image: linear-gradient(rgba(77, 169, 255, 0.1) 0 0);
         background-color: unset;
       }

--- a/src/assets/sass/modules/toast-messages/_toast-messages.scss
+++ b/src/assets/sass/modules/toast-messages/_toast-messages.scss
@@ -23,7 +23,7 @@
     transform: translateX(120%);
     background-color: #fff;
     border-radius: var(--dapp-form-input-border-radius);
-    border-color: var(--border-color);
+    border-color: var(--dapp-form-border-color);
 
     &.clickable {
       cursor: pointer;
@@ -68,7 +68,7 @@
   .close {
     opacity: 1;
     svg {
-      color: var(--secondary);
+      color: var(--dapp-form-secondary);
     }
   }
 }

--- a/src/assets/sass/modules/token-symbol/tokenSymbol.scss
+++ b/src/assets/sass/modules/token-symbol/tokenSymbol.scss
@@ -5,11 +5,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--white);
+  background-color: var(--dapp-form-white);
   border-radius: 50%;
   svg {
     #egld-token {
-      fill: var(--black);
+      fill: var(--dapp-form-black);
     }
   }
 }
@@ -19,7 +19,7 @@
 }
 
 .token-symbol {
-  border: 1px solid var(--black);
+  border: 1px solid var(--dapp-form-black);
   width: 2rem;
   height: 2rem;
 
@@ -43,7 +43,7 @@
   svg {
     filter: drop-shadow(0 0 0.25rem $black);
     circle {
-      fill: var(--card-bg);
+      fill: var(--dapp-form-card-bg);
     }
   }
   width: 4.5rem;

--- a/src/assets/sass/modules/trim/_trim.scss
+++ b/src/assets/sass/modules/trim/_trim.scss
@@ -75,7 +75,7 @@
 }
 
 a:hover > .trim span {
-  color: var(--link-hover-color);
+  color: var(--dapp-form-link-hover-color);
   &.hidden-text-ref {
     color: transparent;
   }
@@ -83,7 +83,7 @@ a:hover > .trim span {
 
 a > .trim span,
 .text-primary > .trim span {
-  color: var(--primary);
+  color: var(--dapp-form-primary);
   &.hidden-text-ref {
     color: transparent;
   }

--- a/src/assets/sass/themes/theme.scss
+++ b/src/assets/sass/themes/theme.scss
@@ -18,17 +18,17 @@ html {
 
 a,
 .link-style {
-  color: var(--primary-light);
+  color: var(--dapp-form-primary-light);
 }
 
 .link-second-style {
-  color: var(--secondary);
+  color: var(--dapp-form-secondary);
 
   &:hover {
-    color: var(--primary-light);
+    color: var(--dapp-form-primary-light);
 
     svg {
-      color: var(--primary-light);
+      color: var(--dapp-form-primary-light);
     }
   }
 }
@@ -44,7 +44,7 @@ a,
 .dapp-icon {
   padding: 5px;
   border-radius: 50%;
-  background-color: var(--light);
+  background-color: var(--dapp-form-light);
   width: toRem(65);
   height: toRem(65);
   display: flex;
@@ -96,20 +96,20 @@ a,
     justify-content: center;
     align-items: center;
     color: #fff;
-    background-color: var(--primary-light);
+    background-color: var(--dapp-form-primary-light);
     padding: 15px 20px 15px 16px;
     border-radius: 6px;
     gap: 8px;
 
     &:hover,
     &:active {
-      background-color: var(--primary-light);
+      background-color: var(--dapp-form-primary-light);
       background-image: linear-gradient(rgba(0, 0, 0, 0.1) 0 0);
     }
   }
 
   .info {
-    color: var(--primary-light);
+    color: var(--dapp-form-primary-light);
     margin-left: 48px;
   }
 }
@@ -152,14 +152,14 @@ a,
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  color: var(--white);
+  color: var(--dapp-form-white);
   margin: 0 7px;
 
   button {
     border-radius: 50%;
     width: 40px;
     height: 40px;
-    background-color: var(--white);
+    background-color: var(--dapp-form-white);
 
     &:hover {
       opacity: 0.9;
@@ -182,7 +182,7 @@ a,
 
     tr:last-of-type {
       td {
-        border-bottom: 1px solid var(--border-color);
+        border-bottom: 1px solid var(--dapp-form-border-color);
       }
     }
   }

--- a/src/assets/sass/variables/_variables.scss
+++ b/src/assets/sass/variables/_variables.scss
@@ -15,19 +15,19 @@ $warning: #ffc107 !default;
 $btn-blue: #163aa0 !default;
 
 :root {
-  --primary: #1b46c2;
-  --primary-light: #1392ff;
-  --border-color: #dee2e6;
-  --card-bg: white;
-  --black: black;
-  --light: #fafafa;
-  --secondary: #6c757d;
-  --card-bg: #ffffff;
-  --border-color: #dee2e6;
-  --warning: #ffc107;
-  --btn-blue: #163aa0;
-  --brown: #212529;
-  --link-hover-color: #122e7f;
+  --dapp-form-primary: #1b46c2;
+  --dapp-form-primary-light: #1392ff;  
+  --dapp-form-black: black;
+  --dapp-form-white: white;
+  --dapp-form-light: #fafafa;
+  --dapp-form-muted: #737373;
+  --dapp-form-secondary: #6c757d;
+  --dapp-form-card-bg: #ffffff;
+  --dapp-form-border-color: #dee2e6;
+  --dapp-form-warning: #ffc107;
+  --dapp-form-btn-blue: #163aa0;
+  --dapp-formbrown: #212529;
+  --dapp-form-link-hover-color: #122e7f;
 
   --dapp-form-bg: #242526;
   --dapp-form-label-color: #9ba5b4;

--- a/src/helpers/misc/selectCustomStyles.ts
+++ b/src/helpers/misc/selectCustomStyles.ts
@@ -1,10 +1,10 @@
 export function selectCustomStyles({ docStyle }: { docStyle: any }) {
   const customColors = {
-    hoverColor: docStyle.getPropertyValue('--border-color'),
-    primaryColor: docStyle.getPropertyValue('--primary'),
-    bgColor: docStyle.getPropertyValue('--card-bg'),
-    mutedColor: docStyle.getPropertyValue('--muted'),
-    blackColor: docStyle.getPropertyValue('--black')
+    hoverColor: docStyle.getPropertyValue('--dapp-form-border-color'),
+    primaryColor: docStyle.getPropertyValue('--dapp-form-primary'),
+    bgColor: docStyle.getPropertyValue('--dapp-form-card-bg'),
+    mutedColor: docStyle.getPropertyValue('--dapp-form-muted'),
+    blackColor: docStyle.getPropertyValue('--dapp-form-black')
   };
 
   return {


### PR DESCRIPTION

### Issue/Feature
The global css variables would overwrite css variables in projects including the sdk-dapp-form package

### Reproduce
Issue exists on version `` of sdk-dapp-form

### Fix

added the `dapp-form` prefix to the global css variables to avoid interferrence with other dapps that could include this package

### Additional changes

### Contains breaking changes
[x] No
[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User tesing
[] Unit tests
