### PR TITLE
Changed receiver form validation during `Burn` NFT transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Changed receiver form validation during `Burn` NFT transaction](https://github.com/multiversx/mx-sdk-dapp-form/pull/257)
+
 ## [[0.8.21](https://github.com/multiversx/mx-sdk-dapp-form/pull/256)] - 2023-11-17
 
 - [Fixed long fee styles and max amount formatting](https://github.com/multiversx/mx-sdk-dapp-form/pull/255)

--- a/src/containers/SendFormContainer.tsx
+++ b/src/containers/SendFormContainer.tsx
@@ -125,23 +125,24 @@ export function SendFormContainer(props: SendFormContainerPropsType) {
     getGasLimit({ txType, data, isGuarded: accountInfo.isGuarded });
 
   const formikInitialValues = {
-    tokenId,
+    address: initialValues?.address ?? address,
+    amount: initialValues?.amount ?? ZERO,
+    balance: initialValues?.balance || balance,
+    chainId: initialValues?.chainId || networkConfig.chainId,
+    code: '',
+    data,
+    gasLimit,
+    gasPrice: initialValues?.gasPrice ?? formattedConfigGasPrice,
+    isBurn: formInfo.isBurn,
+    isGuarded: initialValues?.isGuarded ?? accountInfo.isGuarded,
+    ledger: initialValues?.ledger,
+    nft: tokensInfo?.initialNft,
     receiver: initialValues?.receiver ?? '',
     receiverUsername: initialValues?.receiverUsername,
     senderUsername: username,
-    gasPrice: initialValues?.gasPrice ?? formattedConfigGasPrice,
-    data,
-    amount: initialValues?.amount ?? ZERO,
-    gasLimit,
-    txType,
-    address: initialValues?.address ?? address,
-    nft: tokensInfo?.initialNft,
-    balance: initialValues?.balance || balance,
-    isGuarded: initialValues?.isGuarded ?? accountInfo.isGuarded,
-    chainId: initialValues?.chainId || networkConfig.chainId,
+    tokenId,
     tokens: tokensInfo?.initialTokens,
-    ledger: initialValues?.ledger,
-    code: ''
+    txType
   };
 
   return (

--- a/src/contexts/FormContext/FormContext.tsx
+++ b/src/contexts/FormContext/FormContext.tsx
@@ -19,17 +19,18 @@ import {
 import { verifyInvalid } from 'validation';
 
 export interface FormContextBasePropsType {
-  prefilledForm: boolean;
-  skipToConfirm?: boolean;
-  readonly?: ExtendedValuesType['readonly'];
-  hiddenFields?: ExtendedValuesType['hiddenFields'];
-  uiOptions?: ExtendedValuesType['uiOptions'];
-  onCloseForm: () => void;
-  isFormSubmitted: boolean;
-  setIsFormSubmitted: Dispatch<SetStateAction<boolean>>;
-  setGuardedTransaction: (transaction: Transaction) => void;
   hasGuardianScreen: boolean;
+  hiddenFields?: ExtendedValuesType['hiddenFields'];
+  isBurn?: boolean;
+  isFormSubmitted: boolean;
+  onCloseForm: () => void;
+  prefilledForm: boolean;
+  readonly?: ExtendedValuesType['readonly'];
+  setGuardedTransaction: (transaction: Transaction) => void;
   setHasGuardianScreen: Dispatch<SetStateAction<boolean>>;
+  setIsFormSubmitted: Dispatch<SetStateAction<boolean>>;
+  skipToConfirm?: boolean;
+  uiOptions?: ExtendedValuesType['uiOptions'];
 }
 
 export interface FormContextPropsType extends FormContextBasePropsType {

--- a/src/operations/getTxType.ts
+++ b/src/operations/getTxType.ts
@@ -14,18 +14,23 @@ export function getTxType({
   if (isEgld) {
     return TransactionTypeEnum.EGLD;
   }
+
   if (nft?.type === NftEnumType.NonFungibleESDT) {
     return TransactionTypeEnum.NonFungibleESDT;
   }
+
   if (nft?.type === NftEnumType.SemiFungibleESDT) {
     return TransactionTypeEnum.SemiFungibleESDT;
   }
+
   if (nft?.type === NftEnumType.MetaESDT || isNft) {
     return TransactionTypeEnum.MetaESDT;
   }
+
   if (isEsdt) {
     return TransactionTypeEnum.ESDT;
   }
+
   return TransactionTypeEnum.EGLD;
 }
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -32,25 +32,26 @@ export interface ValuesType
 
 export interface ExtendedValuesType extends ValuesType {
   // validationSchema
-  txType: TransactionTypeEnum;
   address: string;
-  isGuarded?: boolean;
   balance: string;
   chainId: string;
+  hiddenFields?: Array<ValueKeyType>;
   ignoreTokenBalance?: boolean;
+  isBurn?: boolean;
+  isGuarded?: boolean;
+  ledger?: {
+    ledgerDataActive: boolean;
+    version: string;
+  };
+  nft?: PartialNftType;
   /**
    * **readonly**: Configure disabled fields by disabling all or individual fields.\
    * Example: `readonly: [ 'amount' ]` will disable only the amount field.
    */
   readonly?: boolean | Array<ValueKeyType>;
-  hiddenFields?: Array<ValueKeyType>;
-  nft?: PartialNftType;
   tokens?: PartialTokenType[] | null;
-  ledger?: {
-    ledgerDataActive: boolean;
-    version: string;
-  };
   transaction?: Transaction;
+  txType: TransactionTypeEnum;
   uiOptions?: {
     showAmountSlider: boolean;
   };

--- a/src/validationSchema/receiver.ts
+++ b/src/validationSchema/receiver.ts
@@ -17,14 +17,14 @@ export const receiver = (errorMessages: ValidationErrorMessagesType) => {
     'sameAddress',
     errorMessages.sameAsOwnerAddress,
     function sameAddressCheck(value) {
-      const { ignoreTokenBalance, txType, readonly, address } = this
+      const { ignoreTokenBalance, txType, readonly, address, isBurn } = this
         .parent as ExtendedValuesType;
       const isNftTransaction = getIsNftTransaction(txType);
-      const signContext = ignoreTokenBalance;
 
-      if (isNftTransaction && !signContext && !readonly) {
+      if (isNftTransaction && !ignoreTokenBalance && !readonly && !isBurn) {
         return address !== value;
       }
+
       return true;
     }
   );
@@ -48,13 +48,7 @@ export const receiver = (errorMessages: ValidationErrorMessagesType) => {
         return true;
       }
 
-      const isReceiverNotAllwed = !allowedReceivers.includes(value);
-
-      if (isReceiverNotAllwed) {
-        return false;
-      }
-
-      return true;
+      return allowedReceivers.includes(value);
     }
   );
 


### PR DESCRIPTION
### Issue
Cannot burn `NFT` or `SFT`, because there is an error: "Same receiver adress as sender"

### Reproduce
Issue exists on version `0.8.21` of sdk-dapp-form

### Root cause
Burn `NFT` or `SFT` transaction has same receiver as sender.

### Fix
Add `isBurn` flag and disabled the reciever validation when this flag is `true` (when we are burning)

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User tesing
[] Unit tests
