### PR TITLE
Fixed `Receiver` input overlaps autocomplete selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed `Receiver` input overlaps autocomplete selection](https://github.com/multiversx/mx-sdk-dapp-form/pull/258)
+
 ## [[0.8.22](https://github.com/multiversx/mx-sdk-dapp-form/pull/257)] - 2023-11-23
 
 - [Changed receiver form validation during `Burn` NFT transaction](https://github.com/multiversx/mx-sdk-dapp-form/pull/257)

--- a/src/UI/Fields/Receiver/styles.module.scss
+++ b/src/UI/Fields/Receiver/styles.module.scss
@@ -188,7 +188,7 @@
           }
 
           &.visible input {
-            opacity: 1 !important;
+            opacity: 1;
           }
 
           &.spaced input {
@@ -203,6 +203,10 @@
             line-height: 17px !important;
             font-size: 14px !important;
             color: var(--action-color) !important;
+
+            @media (min-width: 768px) {
+              opacity: 0;
+            }
           }
         }
       }


### PR DESCRIPTION
### Issue
<img width="740" alt="image" src="https://github.com/multiversx/mx-sdk-dapp-form/assets/13073341/fb57f0c9-f45f-4548-9ca9-e493f5e3a133">

### Reproduce
Issue exists on version `0.8.22` of sdk-dapp-form

### Root cause
Opacity of input is not set to 0;

### Fix
Set opacity to 0 on large screens only to allow pasting on mobile

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User tesing
[] Unit tests
